### PR TITLE
Add multi-network WiFi with hotspot fallback

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,9 +33,15 @@
 #include <WebServer.h>
 #include <ArduinoJson.h>
 #include <ArduinoOTA.h>
+#include <ESPmDNS.h>
 #include "web_interface.h"
 #if __has_include("secrets.h")
 #include "secrets.h"
+#ifdef WIFI_NETWORKS_DEFINED
+#pragma message "secrets.h loaded OK"
+#else
+#pragma message "secrets.h NOT found - will use hotspot"
+#endif
 #endif
 #endif
 
@@ -53,15 +59,6 @@
 #define ENABLE_PIN 4
 #endif
 
-// WiFi credentials (for web server mode)
-#ifndef WIFI_SSID
-#define WIFI_SSID "YourSSID"
-#endif
-
-#ifndef WIFI_PASS
-#define WIFI_PASS "YourPassword"
-#endif
-
 // Nibble swap helper
 #define SWAP_NIBBLES(x) (((x) & 0x0F) << 4 | ((x) & 0xF0) >> 4)
 
@@ -70,6 +67,7 @@ OneWire<ONEWIRE_PIN> makita;
 
 #ifdef ENABLE_WEB_SERVER
 WebServer server(80);
+bool wifiHotspot = false;  // true if running in hotspot/AP mode
 #endif
 
 // Battery data structure
@@ -105,6 +103,7 @@ bool readBatteryModel();
 #ifdef ENABLE_WEB_SERVER
 void setupWebServer();
 void setupOTA();
+void setupWiFi();
 #endif
 
 // ------------------------------------------------------------------
@@ -134,27 +133,12 @@ void setup() {
 
 #ifdef ENABLE_WEB_SERVER
     Serial.println("Mode: Web Server + Serial Bridge");
-    Serial.println("Connecting to WiFi...");
-
-    WiFi.begin(WIFI_SSID, WIFI_PASS);
-
-    int attempts = 0;
-    while (WiFi.status() != WL_CONNECTED && attempts < 30) {
-        delay(500);
-        Serial.print(".");
-        attempts++;
-    }
+    setupWiFi();
 
     if (WiFi.status() == WL_CONNECTED) {
-        Serial.println();
-        Serial.print("Connected! IP: ");
-        Serial.println(WiFi.localIP());
         setupOTA();
-        setupWebServer();
-    } else {
-        Serial.println();
-        Serial.println("WiFi failed - Serial bridge only");
     }
+    setupWebServer();
 #else
     Serial.println("Mode: Serial Bridge Only");
 #endif
@@ -167,11 +151,93 @@ void setup() {
 // ------------------------------------------------------------------
 void loop() {
 #ifdef ENABLE_WEB_SERVER
-    ArduinoOTA.handle();
+    if (!wifiHotspot) {
+        ArduinoOTA.handle();
+    }
     server.handleClient();
 #endif
     processSerialCommand();
 }
+
+// ------------------------------------------------------------------
+// WiFi Setup - multi-network with hotspot fallback
+// ------------------------------------------------------------------
+#ifdef ENABLE_WEB_SERVER
+void setupWiFi() {
+
+#ifdef WIFI_NETWORKS_DEFINED
+    // Scan for available networks
+    Serial.println("Scanning for WiFi networks...");
+    int found = WiFi.scanNetworks();
+    Serial.printf("Found %d networks\n", found);
+
+    // Try to match a known network from secrets.h
+    const char* matchedSSID = nullptr;
+    const char* matchedPass = nullptr;
+
+    for (int i = 0; i < found && matchedSSID == nullptr; i++) {
+        String scannedSSID = WiFi.SSID(i);
+        for (int j = 0; j < WIFI_NETWORK_COUNT; j++) {
+            if (scannedSSID == WIFI_NETWORKS[j].ssid) {
+                matchedSSID = WIFI_NETWORKS[j].ssid;
+                matchedPass = WIFI_NETWORKS[j].pass;
+                Serial.printf("Matched network: %s\n", matchedSSID);
+                break;
+            }
+        }
+    }
+    WiFi.scanDelete();
+
+    if (matchedSSID != nullptr) {
+        // Connect to matched network
+        Serial.printf("Connecting to %s", matchedSSID);
+        WiFi.begin(matchedSSID, matchedPass);
+
+        unsigned long startMs = millis();
+        while (WiFi.status() != WL_CONNECTED && millis() - startMs < WIFI_TIMEOUT_MS) {
+            delay(500);
+            Serial.print(".");
+        }
+        Serial.println();
+    }
+#endif
+
+    if (WiFi.status() == WL_CONNECTED) {
+        wifiHotspot = false;
+        Serial.print("Connected! IP: ");
+        Serial.println(WiFi.localIP());
+
+        if (MDNS.begin("obi-esp32")) {
+            Serial.println("mDNS started - http://obi-esp32.local");
+        }
+
+    } else {
+        // No known network found or connection timed out — start hotspot
+        wifiHotspot = true;
+        WiFi.mode(WIFI_AP);
+
+        bool apStarted;
+        if (strlen(HOTSPOT_PASS) > 0) {
+            apStarted = WiFi.softAP(HOTSPOT_SSID, HOTSPOT_PASS);
+        } else {
+            apStarted = WiFi.softAP(HOTSPOT_SSID);
+        }
+
+        if (apStarted) {
+            Serial.printf("Hotspot started - SSID: %s\n", HOTSPOT_SSID);
+            if (strlen(HOTSPOT_PASS) > 0) {
+                Serial.printf("Hotspot password: %s\n", HOTSPOT_PASS);
+            } else {
+                Serial.println("Hotspot is open (no password)");
+            }
+            Serial.print("Hotspot IP: ");
+            Serial.println(WiFi.softAPIP());
+        } else {
+            Serial.println("ERROR: Failed to start hotspot");
+        }
+    }
+}
+#endif
 
 // ------------------------------------------------------------------
 // Enable pin control
@@ -406,7 +472,6 @@ bool readBatteryVoltages() {
         }
 
         if (f0513_ok) {
-            // Calculate pack voltage and diff
             float sum = 0, maxV = 0, minV = 5;
             for (int i = 0; i < 5; i++) {
                 sum += batteryData.cellVoltage[i];
@@ -416,11 +481,10 @@ bool readBatteryVoltages() {
             batteryData.packVoltage = sum;
             batteryData.cellDiff = maxV - minV;
 
-            // Temperature (F0513 only has cell temp, no MOSFET temp)
             vcmd[0] = 0x52;
             if (cmdAndReadCC(vcmd, 1, rsp, 2)) {
                 batteryData.tempCell = ((uint16_t)rsp[0] | ((uint16_t)rsp[1] << 8)) / 100.0f;
-                batteryData.tempMosfet = 0;  // Not available on F0513
+                batteryData.tempMosfet = 0;
             }
             success = true;
         }
@@ -551,7 +615,7 @@ void setupOTA() {
 #endif
 
 // ------------------------------------------------------------------
-// Web Server (Phase 2)
+// Web Server
 // ------------------------------------------------------------------
 
 #ifdef ENABLE_WEB_SERVER
@@ -613,12 +677,10 @@ void handleApiLeds() {
     setEnable(true);
     delay(400);
 
-    // Test mode command
     byte cmd1[] = {0xD9, 0x96, 0xA5};
     byte rsp[32];
     cmdAndRead33(cmd1, 3, rsp, 9);
 
-    // LED command
     byte cmd2[] = {0xDA, (byte)(state ? 0x31 : 0x34)};
     cmdAndRead33(cmd2, 2, rsp, 9);
 
@@ -631,12 +693,10 @@ void handleApiReset() {
     setEnable(true);
     delay(400);
 
-    // Test mode
     byte cmd1[] = {0xD9, 0x96, 0xA5};
     byte rsp[32];
     cmdAndRead33(cmd1, 3, rsp, 9);
 
-    // Reset error
     byte cmd2[] = {0xDA, 0x04};
     cmdAndRead33(cmd2, 2, rsp, 9);
 
@@ -654,5 +714,11 @@ void setupWebServer() {
 
     server.begin();
     Serial.println("Web server started on port 80");
+
+    if (wifiHotspot) {
+        Serial.printf("Connect to hotspot '%s' then browse to http://192.168.4.1\n", HOTSPOT_SSID);
+    } else {
+        Serial.println("Browse to http://obi-esp32.local");
+    }
 }
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,6 +34,7 @@
 #include <ArduinoJson.h>
 #include <ArduinoOTA.h>
 #include <ESPmDNS.h>
+#include <DNSServer.h>
 #include "web_interface.h"
 #if __has_include("secrets.h")
 #include "secrets.h"
@@ -67,6 +68,7 @@ OneWire<ONEWIRE_PIN> makita;
 
 #ifdef ENABLE_WEB_SERVER
 WebServer server(80);
+DNSServer dnsServer;
 bool wifiHotspot = false;  // true if running in hotspot/AP mode
 #endif
 
@@ -151,7 +153,9 @@ void setup() {
 // ------------------------------------------------------------------
 void loop() {
 #ifdef ENABLE_WEB_SERVER
-    if (!wifiHotspot) {
+    if (wifiHotspot) {
+        dnsServer.processNextRequest();
+    } else {
         ArduinoOTA.handle();
     }
     server.handleClient();
@@ -224,6 +228,10 @@ void setupWiFi() {
         }
 
         if (apStarted) {
+            // Start DNS server - redirect all DNS queries to our IP
+            // This triggers the captive portal on Android, iOS, Windows, macOS
+            dnsServer.start(53, "*", WiFi.softAPIP());
+
             Serial.printf("Hotspot started - SSID: %s\n", HOTSPOT_SSID);
             if (strlen(HOTSPOT_PASS) > 0) {
                 Serial.printf("Hotspot password: %s\n", HOTSPOT_PASS);
@@ -232,6 +240,7 @@ void setupWiFi() {
             }
             Serial.print("Hotspot IP: ");
             Serial.println(WiFi.softAPIP());
+            Serial.println("Captive portal active - browser should open automatically");
         } else {
             Serial.println("ERROR: Failed to start hotspot");
         }
@@ -705,12 +714,29 @@ void handleApiReset() {
     server.send(200, "application/json", "{\"success\":true}");
 }
 
+void handleCaptivePortal() {
+    // Redirect to root - works for all captive portal detection methods
+    server.sendHeader("Location", "http://192.168.4.1/", true);
+    server.send(302, "text/plain", "");
+}
+
 void setupWebServer() {
     server.on("/", HTTP_GET, handleRoot);
     server.on("/api/read", HTTP_GET, handleApiRead);
     server.on("/api/voltages", HTTP_GET, handleApiVoltages);
     server.on("/api/leds", HTTP_GET, handleApiLeds);
     server.on("/api/reset", HTTP_GET, handleApiReset);
+
+    if (wifiHotspot) {
+        // Captive portal detection endpoints for each OS
+        server.on("/generate_204", HTTP_GET, handleCaptivePortal);           // Android
+        server.on("/gen_204", HTTP_GET, handleCaptivePortal);                // Android fallback
+        server.on("/hotspot-detect.html", HTTP_GET, handleCaptivePortal);   // iOS / macOS
+        server.on("/connecttest.txt", HTTP_GET, handleCaptivePortal);        // Windows
+        server.on("/redirect", HTTP_GET, handleCaptivePortal);               // Windows fallback
+        server.on("/success.txt", HTTP_GET, handleCaptivePortal);            // Firefox
+        server.onNotFound(handleCaptivePortal);  // Catch-all for any other probe URLs
+    }
 
     server.begin();
     Serial.println("Web server started on port 80");

--- a/src/secrets.h.example
+++ b/src/secrets.h.example
@@ -1,9 +1,33 @@
 /**
- * WiFi Credentials
+ * WiFi Credentials - Example Configuration
  *
  * Copy this file to secrets.h and fill in your WiFi credentials.
  * secrets.h is gitignored and will not be committed.
+ *
+ * Multiple networks are supported - the device will scan and connect
+ * to whichever is visible. Add as many networks as needed.
+ *
+ * If no known network is found within WIFI_TIMEOUT_MS milliseconds,
+ * the device starts a hotspot with SSID HOTSPOT_SSID at 192.168.4.1.
  */
 
-#define WIFI_SSID "YourSSID"
-#define WIFI_PASS "YourPassword"
+struct WifiNetwork {
+    const char* ssid;
+    const char* pass;
+};
+
+#define WIFI_NETWORKS_DEFINED
+
+static const WifiNetwork WIFI_NETWORKS[] = {
+    { "YourSSID",        "YourPassword" },
+    { "YourOtherSSID",   "YourOtherPassword" },
+    // Add more networks here as needed:
+    // { "WorkWiFi",     "workpassword" },
+};
+
+static const int WIFI_NETWORK_COUNT = sizeof(WIFI_NETWORKS) / sizeof(WIFI_NETWORKS[0]);
+
+// Hotspot settings (used when no known network is found)
+#define HOTSPOT_SSID     "obi-esp32"       // Name of the fallback hotspot
+#define HOTSPOT_PASS     ""                // Leave empty for open hotspot, or set a password
+#define WIFI_TIMEOUT_MS  30000             // Milliseconds to wait before falling back to hotspot


### PR DESCRIPTION
I felt that the web OBI user interface is way more useful than the original application. Here's a change that allows defining a range of five wifi networks and allows a fallback to a self hosted hotspot. The wifi network credentials are still stored in secrets.h but the layout if the file is more complex.

I'd also wondered if it was worth adding a wifi settings tool to the UI. 
In that way the wifi could say start off in hotspot mode and allow the user to scan for wifi networks and add them via the web console. The passwords could then be stored hashed as a better security measure. 

Hoping this is useful to others.
Ray