### PR TITLE
WIFI Access Point mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This firmware provides a web-based interface for reading Makita LXT battery info
 - **Web Interface**: Responsive single-page application accessible from any browser
 - **Real-time Battery Data**: Cell voltages, pack voltage, temperatures, charge count
 - **mDNS Discovery**: Access via `http://obi-esp32.local`
+- **Access Point Mode**: Optional self-hosted WiFi with captive portal (no router needed) — `http://4.4.4.4` / `http://obi.local`
 - **OTA Updates**: Wireless firmware updates after initial flash
 - **REST API**: JSON endpoints for integration with other systems
 - **Dual Temperature Sensors**: Cell thermistor and MOSFET temperatures
@@ -106,8 +107,14 @@ cp src/secrets.h.example src/secrets.h
 Then edit `src/secrets.h` with your WiFi credentials:
 
 ```cpp
+// Station mode: the network the ESP32 joins
 #define WIFI_SSID "YourSSID"
 #define WIFI_PASS "YourPassword"
+
+// Access Point mode: the network the ESP32 broadcasts
+// AP_PASS must be at least 8 characters (WPA2 requirement)
+#define AP_SSID "OBI-ESP32"
+#define AP_PASS "obi12345"
 ```
 
 The `secrets.h` file is gitignored, so your credentials won't be committed to version control.
@@ -140,6 +147,49 @@ sudo firewall-cmd --runtime-to-permanent
 ```
 
 ## Usage
+
+### Access Point Mode (No Router Needed)
+
+By default (`esp32c3_web`) the ESP32 **joins** your existing WiFi. The `esp32c3_ap`
+environment instead makes the ESP32 **broadcast its own** WiFi network, so you can
+use it anywhere with no router — handy in the field.
+
+When you connect to the AP, a **captive portal** opens the interface automatically
+(same popup as airport/hotel WiFi). If it doesn't appear, browse to
+`http://4.4.4.4` or `http://obi.local` manually.
+
+The AP credentials come from `AP_SSID` / `AP_PASS` in `src/secrets.h` (default
+SSID `OBI-ESP32`, password `obi12345`).
+
+```bash
+# Build and flash AP firmware via USB
+pio run -e esp32c3_ap -t upload
+
+# Monitor serial output (shows AP IP and captive portal status)
+pio device monitor
+```
+
+Then on your phone or laptop:
+
+1. Join the WiFi network `OBI-ESP32` (password `obi12345`)
+2. The battery interface opens automatically via the captive portal
+3. Or open `http://4.4.4.4` / `http://obi.local`
+
+#### OTA Updates (AP Mode)
+
+Once the AP firmware is running, update it wirelessly while connected to the
+`OBI-ESP32` network:
+
+```bash
+# Upload via OTA over the Access Point
+pio run -e esp32c3_ap_ota -t upload
+```
+
+The OTA target IP is fixed to `4.4.4.4` in `platformio.ini`.
+
+> **Note:** Captive-portal popups run in a restricted mini-browser. For full
+> functionality (and to stop the OS from dropping the AP as "no internet"),
+> choose "use network as-is" / open a normal browser to `http://4.4.4.4`.
 
 ### Finding the Device
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,13 +28,13 @@ build_flags =
     -DENABLE_PIN=4
 
 ; Monitor settings
-monitor_port = /dev/cu.usbmodem1101
+monitor_port = /dev/ttyACM0
 monitor_speed = 115200
 monitor_filters = direct, esp32_exception_decoder
 
 ; Upload settings
 upload_speed = 921600
-upload_port = /dev/cu.usbmodem1101
+upload_port = /dev/ttyACM0
 
 ; Library dependencies
 lib_deps =

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,13 +28,13 @@ build_flags =
     -DENABLE_PIN=4
 
 ; Monitor settings
-monitor_port = /dev/ttyACM0
+monitor_port = /dev/cu.usbmodem1101
 monitor_speed = 115200
 monitor_filters = direct, esp32_exception_decoder
 
 ; Upload settings
 upload_speed = 921600
-upload_port = /dev/ttyACM0
+upload_port = /dev/cu.usbmodem1101
 
 ; Library dependencies
 lib_deps =
@@ -50,9 +50,24 @@ build_flags =
 lib_deps =
     bblanchon/ArduinoJson @ ^7.0.0
 
+; WiFi Access Point environment - ESP32 broadcasts its own network.
+; Reachable at http://4.4.4.4 or http://obi.local (creds in secrets.h: AP_SSID/AP_PASS)
+[env:esp32c3_ap]
+extends = env:esp32c3_web
+build_flags =
+    ${env:esp32c3_web.build_flags}
+    -DENABLE_WEB_SERVER=1
+    -DENABLE_WIFI_POINT=1
+
 ; OTA upload environment - use after initial USB flash
 [env:esp32c3_ota]
 extends = env:esp32c3_web
 upload_protocol = espota
 upload_port = 192.168.25.110
+
+; OTA upload over the Access Point network
+[env:esp32c3_ap_ota]
+extends = env:esp32c3_ap
+upload_protocol = espota
+upload_port = 4.4.4.4
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,8 @@
  * - Battery Pin 6: Enable (must be HIGH during communication)
  *
  * MODES:
- * - Build with -DENABLE_WEB_SERVER=1 for standalone web interface
+ * - Build with -DENABLE_WEB_SERVER=1 for web interface (joins existing WiFi)
+ * - Add -DENABLE_WIFI_POINT=1 to broadcast own AP (http://4.4.4.4 / obi.local)
  * - Default build provides serial bridge compatible with Python GUI
  *
  * PROTOCOL (Serial Bridge):
@@ -34,6 +35,10 @@
 #include <ArduinoJson.h>
 #include <ArduinoOTA.h>
 #include "web_interface.h"
+#ifdef ENABLE_WIFI_POINT
+#include <ESPmDNS.h>
+#include <DNSServer.h>
+#endif
 #if __has_include("secrets.h")
 #include "secrets.h"
 #endif
@@ -62,6 +67,15 @@
 #define WIFI_PASS "YourPassword"
 #endif
 
+// Access Point credentials (for WiFi point mode)
+#ifndef AP_SSID
+#define AP_SSID "OBI-ESP32"
+#endif
+
+#ifndef AP_PASS
+#define AP_PASS "obi12345"
+#endif
+
 // Nibble swap helper
 #define SWAP_NIBBLES(x) (((x) & 0x0F) << 4 | ((x) & 0xF0) >> 4)
 
@@ -70,6 +84,11 @@ OneWire<ONEWIRE_PIN> makita;
 
 #ifdef ENABLE_WEB_SERVER
 WebServer server(80);
+#endif
+
+#ifdef ENABLE_WIFI_POINT
+DNSServer dnsServer;
+const byte DNS_PORT = 53;
 #endif
 
 // Battery data structure
@@ -133,7 +152,40 @@ void setup() {
     Serial.printf("Enable Pin: GPIO%d\n", ENABLE_PIN);
 
 #ifdef ENABLE_WEB_SERVER
-    Serial.println("Mode: Web Server + Serial Bridge");
+#ifdef ENABLE_WIFI_POINT
+    // Access Point mode - ESP32 broadcasts its own WiFi network
+    Serial.println("Mode: WiFi Access Point + Web Server + Serial Bridge");
+
+    IPAddress apIP(4, 4, 4, 4);
+    IPAddress apSubnet(255, 255, 255, 0);
+
+    WiFi.mode(WIFI_AP);
+    WiFi.softAPConfig(apIP, apIP, apSubnet);
+
+    if (WiFi.softAP(AP_SSID, AP_PASS)) {
+        Serial.printf("Access Point started: SSID '%s'\n", AP_SSID);
+        Serial.print("AP IP: ");
+        Serial.println(WiFi.softAPIP());
+
+        if (MDNS.begin("obi")) {
+            MDNS.addService("http", "tcp", 80);
+            Serial.println("Reachable at http://4.4.4.4 and http://obi.local");
+        }
+
+        // Captive portal: resolve every hostname to the AP so the OS
+        // auto-opens the page the moment a device joins the network.
+        dnsServer.setErrorReplyCode(DNSReplyCode::NoError);
+        dnsServer.start(DNS_PORT, "*", apIP);
+        Serial.println("Captive portal active - page opens automatically on connect");
+
+        setupOTA();
+        setupWebServer();
+    } else {
+        Serial.println("Access Point failed to start - Serial bridge only");
+    }
+#else
+    // Station mode - ESP32 joins an existing WiFi network
+    Serial.println("Mode: Web Server (Station) + Serial Bridge");
     Serial.println("Connecting to WiFi...");
 
     WiFi.begin(WIFI_SSID, WIFI_PASS);
@@ -155,6 +207,7 @@ void setup() {
         Serial.println();
         Serial.println("WiFi failed - Serial bridge only");
     }
+#endif
 #else
     Serial.println("Mode: Serial Bridge Only");
 #endif
@@ -166,6 +219,9 @@ void setup() {
 // Main Loop
 // ------------------------------------------------------------------
 void loop() {
+#ifdef ENABLE_WIFI_POINT
+    dnsServer.processNextRequest();
+#endif
 #ifdef ENABLE_WEB_SERVER
     ArduinoOTA.handle();
     server.handleClient();
@@ -645,12 +701,32 @@ void handleApiReset() {
     server.send(200, "application/json", "{\"success\":true}");
 }
 
+#ifdef ENABLE_WIFI_POINT
+void handleCaptivePortal() {
+    // Any unknown request is an OS connectivity probe (Apple/Android/Windows).
+    // Redirecting it to the portal makes the captive popup appear and load the UI.
+    server.sendHeader("Location", "http://4.4.4.4/", true);
+    server.send(302, "text/plain", "");
+}
+#endif
+
 void setupWebServer() {
     server.on("/", HTTP_GET, handleRoot);
     server.on("/api/read", HTTP_GET, handleApiRead);
     server.on("/api/voltages", HTTP_GET, handleApiVoltages);
     server.on("/api/leds", HTTP_GET, handleApiLeds);
     server.on("/api/reset", HTTP_GET, handleApiReset);
+
+#ifdef ENABLE_WIFI_POINT
+    // Apple's probe expects the literal "Success" page; anything else triggers
+    // the captive popup. Send a redirect for it and every other unknown path.
+    server.on("/hotspot-detect.html", HTTP_GET, handleCaptivePortal);
+    server.on("/generate_204", HTTP_GET, handleCaptivePortal);
+    server.on("/gen_204", HTTP_GET, handleCaptivePortal);
+    server.on("/ncsi.txt", HTTP_GET, handleCaptivePortal);
+    server.on("/connecttest.txt", HTTP_GET, handleCaptivePortal);
+    server.onNotFound(handleCaptivePortal);
+#endif
 
     server.begin();
     Serial.println("Web server started on port 80");

--- a/src/secrets.h.example
+++ b/src/secrets.h.example
@@ -5,5 +5,11 @@
  * secrets.h is gitignored and will not be committed.
  */
 
+// Station mode (-DENABLE_WEB_SERVER): network the ESP32 joins
 #define WIFI_SSID "YourSSID"
 #define WIFI_PASS "YourPassword"
+
+// Access Point mode (-DENABLE_WIFI_POINT): network the ESP32 broadcasts.
+// AP_PASS must be at least 8 characters (WPA2 requirement).
+#define AP_SSID "OBI-ESP32"
+#define AP_PASS "obi12345"


### PR DESCRIPTION
### WiFi Access Point mode with captive portal

  Adds an optional Access Point (AP) mode so the ESP32 broadcasts its own WiFi network instead of joining an
  existing one — no router needed, ideal for field use. When a device joins, a captive portal auto-opens the
  battery interface.

#### What changed

  - New `ENABLE_WIFI_POINT` build flag — when set, the firmware runs softAP instead of station mode. All AP code is
  wrapped in #ifdef ENABLE_WIFI_POINT; the default esp32c3_web (station) path is unchanged.
  - Fixed AP address — gateway 4.4.4.4 + mDNS obi.local, both serving the existing web UI.
  - Captive portal — a DNSServer resolves all hostnames to 4.4.4.4, and OS connectivity probes
  (Apple/Android/Windows) get a 302 redirect, triggering the auto-open popup.
  - New PlatformIO envs — esp32c3_ap (USB flash) and esp32c3_ap_ota (OTA over 4.4.4.4).
  - Credentials — AP_SSID / AP_PASS added to secrets.h / secrets.h.example (default OBI-ESP32 / obi12345; WPA2
  needs ≥8 chars).
  - Docs — README gains an "Access Point Mode" usage section with flash + OTA examples and a feature bullet.

#### Usage

```bash
  pio run -e esp32c3_ap -t upload        # flash AP firmware via USB
  pio run -e esp32c3_ap_ota -t upload    # wireless update over the AP
```
  Join `OBI-ESP32` → interface opens via captive portal, or browse http://4.4.4.4 / http://obi.local.

